### PR TITLE
Secondary index

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,11 +111,9 @@ Or just go to the admin page.
 
 ## Debates
 ### Unique short url by full url
-For now, each time a same url is requested to be shorten, a new short url is created.
+If an known url is submitted, the existing id is returned.
 
-In the case of the statistics (number of views) are available for the users, they might want to know how many times THEIR short url has been used.
-
-Otherwise, the code should check if a key has already been associated to that url. But then, we would need a way to [lock](https://github.com/Philmod/node-redis-lock) the request for a specific url.
+In the case of the statistics (number of views) are available for the users, that's an issue because 2 people can share the same statistics for a same url.
 
 Another open question would be : "What about `http://` vs `https://`"? Do they have a different short url?
 

--- a/app/models/Url.js
+++ b/app/models/Url.js
@@ -4,6 +4,7 @@ const config = require('config');
 const urlLib = require('../lib/url');
 const dynamoLib = require('../lib/dynamo');
 const _ = require('lodash');
+const async = require('async');
 
 const NB_CHAR = 6; // Size of the unique id
 
@@ -54,28 +55,43 @@ module.exports = app => {
    * @return {Function} Callback function
    */
   const insert = (url, id, callback) => {
-    if (idToUrl[id]) {
-      return callback(new errors.ConflictError('Collision'));
-    } else {
-      var data = {
-        id: id,
-        shortUrl: urlLib.constructShortUrl(id),
-        fullUrl: url,
-        date: new Date().toString(),
-        viewCount: 0
-      };
-      var params = _.extend(_.cloneDeep(dynamoParams), {
-        Item: dynamoLib.wrapObject(data, dynamoModel)
-      });
-
-      app.dynamodb.putItem(params, (err) => {
-        if (err) return callback(err);
-        else {
-          idToUrl.set(id, data);
-          return callback(null, id);
+    async.auto({
+      checkExistingUrl: done => {
+        getByFullUrl(url, done);
+      },
+      checkExistingId: done => {
+        if (idToUrl[id]) {
+          return done(new errors.ConflictError('Collision'));
+        } else {
+          return done();
         }
-      });
-    }
+      },
+      insertIntoDatabase: ['checkExistingUrl', 'checkExistingId', (done, results) => {
+        if (results.checkExistingUrl) {
+          return done(null, results.checkExistingUrl.id);
+        }
+        var data = {
+          id: id,
+          shortUrl: urlLib.constructShortUrl(id),
+          fullUrl: url,
+          date: new Date().toString(),
+          viewCount: 0
+        };
+        var params = _.extend(_.cloneDeep(dynamoParams), {
+          Item: dynamoLib.wrapObject(data, dynamoModel)
+        });
+
+        app.dynamodb.putItem(params, (err) => {
+          if (err) return done(err);
+          else {
+            idToUrl.set(id, data);
+            return done(null, id);
+          }
+        });
+      }]
+    }, function(err, results) {
+      callback(err, results.insertIntoDatabase);
+    });
   }
 
   /**
@@ -131,6 +147,32 @@ module.exports = app => {
       else {
         var item = dynamoLib.unwrapDocument(data.Item);
         idToUrl.set(id, item);
+        return callback(null, item);
+      }
+    });
+  }
+
+  /**
+    * Get item by full url.
+    *
+    * @param {String} url
+    * @return {Function} Callback function
+    */
+  const getByFullUrl = (fullUrl, callback) => {
+    // Dynamo object
+    var params = _.extend(_.cloneDeep(dynamoParams), {
+      IndexName: "url",
+      KeyConditionExpression: "fullUrl = :url",
+      ExpressionAttributeValues: {
+        ":url": {S: fullUrl}
+      },
+      Limit: 1
+    });
+
+    app.dynamodb.query(params, (err, data) => {
+      if (err) return callback(err);
+      else {
+        var item = dynamoLib.unwrapDocument(data.Items[0]);
         return callback(null, item);
       }
     });

--- a/app/models/Url.js
+++ b/app/models/Url.js
@@ -120,18 +120,16 @@ module.exports = app => {
 
     // Dynamo object
     var params = _.extend(_.cloneDeep(dynamoParams), {
-      KeyConditionExpression: "id = :v1",
-      ExpressionAttributeValues: {
-        ":v1": {S: id}
+      Key: {
+        id: {S: id}
       },
-      Limit: 1,
       ConsistentRead: true
     });
 
-    app.dynamodb.query(params, (err, data) => {
+    app.dynamodb.getItem(params, (err, data) => {
       if (err) return callback(err);
       else {
-        var item = dynamoLib.unwrapDocument(data.Items[0]);
+        var item = dynamoLib.unwrapDocument(data.Item);
         idToUrl.set(id, item);
         return callback(null, item);
       }

--- a/config/dynamoUrlsSchema.json
+++ b/config/dynamoUrlsSchema.json
@@ -3,6 +3,10 @@
     {
       "AttributeName": "id",
       "AttributeType": "S"
+    },
+    {
+      "AttributeName": "fullUrl",
+      "AttributeType": "S"
     }
   ],
   "KeySchema": [
@@ -15,5 +19,23 @@
     "ReadCapacityUnits": 1,
     "WriteCapacityUnits": 1
   },
-  "TableName": ""
+  "TableName": "",
+  "GlobalSecondaryIndexes": [
+    {
+      "IndexName": "url",
+      "KeySchema": [
+        {
+          "AttributeName": "fullUrl",
+          "KeyType": "HASH"
+        }
+      ],
+      "Projection": {
+        "ProjectionType": "KEYS_ONLY"
+      },
+      "ProvisionedThroughput": {
+        "ReadCapacityUnits": 1,
+        "WriteCapacityUnits": 1
+      }
+    }
+  ]
 }

--- a/config/production.json
+++ b/config/production.json
@@ -8,8 +8,8 @@
     "password": "f235924b7c314c596cdb498e3a7e3b2b"
   },
   "aws": {
-    "accessKeyId": "AKIAIH4Q423JMLTC74DQ",
-    "secretAccessKey": "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",
+    "accessKeyId": "",
+    "secretAccessKey": "",
     "region": "us-east-1"
   },
   "database": {

--- a/test/api.routes.test.js
+++ b/test/api.routes.test.js
@@ -32,6 +32,32 @@ describe('api.routes.test.js', () => {
         });
     });
 
+    describe('Same Url', () => {
+
+      const url = 'https://hello-belgium.com';
+      const id = 'belg1';
+
+      beforeEach(done => {
+        models.Url.insert(url, id, done);
+      });
+
+      it('successfully uses the same id for a same url', (done) => {
+        request(app)
+          .post('/api/urls')
+          .send({
+            url: url
+          })
+          .expect(200)
+          .end((e, res) => {
+            expect(e).to.not.exist;
+            var shortUrl = res.text;
+            expect(shortUrl).to.contain(id);
+            done();
+          });
+      });
+
+    });
+
   });
 
   describe('GET /api/urls/:id', () => {


### PR DESCRIPTION
In order to avoid a same URL to have different ID.

That also means that the statistics are per url: if 2 users wants a short url for a same long one, they will share the number of views.

We could implement a [locking system](https://github.com/Philmod/node-redis-lock) in order to avoid having two different short urls for a same full url. But it's probably overkilled.